### PR TITLE
Fixed syntax error in factories.rb

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,11 @@ GEM
     diff-lcs (1.3)
     erubi (1.8.0)
     execjs (2.7.0)
+    factory_bot (5.0.2)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.0.2)
+      factory_bot (~> 5.0.2)
+      railties (>= 4.2.0)
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -244,6 +249,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   devise
+  factory_bot_rails
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
     sequence :email do |n|
-      { "dummyEmail#{n}@gmail.com" }
+      "dummyEmail#{n}@gmail.com"
     end
     password { "secretPassword" }
     password_confirmation { "secretPassword" }


### PR DESCRIPTION
Fixes a syntax error that was listed in the course instructions. 